### PR TITLE
fix: use __has_include for jsoncpp check in GeminiClient.cpp

### DIFF
--- a/app/lib/GeminiClient.cpp
+++ b/app/lib/GeminiClient.cpp
@@ -5,12 +5,13 @@
 #include "Utils.hpp"
 
 #include <curl/curl.h>
-#ifdef _WIN32
-    #include <json/json.h>
-#elif __APPLE__
+
+#if __has_include(<jsoncpp/json/json.h>)
+    #include <jsoncpp/json/json.h>
+#elif __has_include(<json/json.h>)
     #include <json/json.h>
 #else
-    #include <jsoncpp/json/json.h>
+    #error "jsoncpp headers not found. Install jsoncpp development files."
 #endif
 
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
GeminiClient.cpp hardcodes jsoncpp/json/json.h in the else branch, which only works on Debian/Ubuntu. On Arch Linux, jsoncpp installs to <json/json.h>, causing a compile error.
I Replace the hardcoded path with __has_include which is used elsewhere in the code aswell