### PR TITLE
Fixed exception for vcpkg path in CMakeLists.txt by adjusting pattern match

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -184,7 +184,7 @@ function(aifs_assert_path_not_in_repo path_value label)
         # vcpkg manifest mode can stage package-managed headers/libs inside the
         # build tree under a local vcpkg_installed directory. That is still a
         # package-manager origin, not vendored MediaInfo content.
-        if(_entry_norm MATCHES "(^|/)vcpkg_installed(/|$)")
+        if(_entry_norm MATCHES "(^|/)(vcpkg_installed|build-windows-vcpkg_installed)(/|$)")
             continue()
         endif()
         if(_entry_norm MATCHES "^${_repo_root_regex}(/|$)")


### PR DESCRIPTION
The only change is in CMakeLists, as written it only matches if vcpkg_installed is the whole directory name, enclosed by slashes.

It doesn't work with the non-legacy path at least when building for windows on windows, where 

$legacySharedVcpkgInstalledDir = Join-Path $appDir "build-windows\\vcpkg_installed"
$dedicatedSharedVcpkgInstalledDir = Join-Path $appDir "build-windows-vcpkg_installed"

