### PR TITLE
fix(llm): fix download timeout and UI freezing on Windows

### DIFF
--- a/app/lib/LLMDownloader.cpp
+++ b/app/lib/LLMDownloader.cpp
@@ -10,6 +10,8 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <winhttp.h>
+#pragma comment(lib, "winhttp.lib")
 #include <system_error>
 #include <stdexcept>
 #ifdef _WIN32
@@ -334,6 +336,7 @@ void LLMDownloader::start_download(std::function<void(double)> progress_cb,
 
     download_thread = std::thread([this]() {
         try {
+            init_if_needed();
             perform_download();
         } catch (const std::exception& ex) {
             download_active.store(false, std::memory_order_relaxed);
@@ -506,22 +509,43 @@ void LLMDownloader::setup_common_curl_options(CURL* curl)
     } catch (const std::exception& ex) {
         throw std::runtime_error(std::string("Failed to stage CA bundle: ") + ex.what());
     }
+    WINHTTP_CURRENT_USER_IE_PROXY_CONFIG proxyConfig = { 0 };   //checking whether proxy exist
+    if (WinHttpGetIEProxyConfigForCurrentUser(&proxyConfig)) {
+        if (proxyConfig.lpszProxy != nullptr) {
+
+            std::wstring proxyW(proxyConfig.lpszProxy);
+            std::string proxyA(proxyW.begin(), proxyW.end());
+            
+            curl_easy_setopt(curl, CURLOPT_PROXY, proxyA.c_str());
+            
+            GlobalFree(proxyConfig.lpszProxy);
+        }
+        if (proxyConfig.lpszProxyBypass != nullptr) GlobalFree(proxyConfig.lpszProxyBypass);
+        if (proxyConfig.lpszAutoConfigUrl != nullptr) GlobalFree(proxyConfig.lpszAutoConfigUrl);
+    }
 #endif
+
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 15L);
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+    curl_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
 }
 
 
 void LLMDownloader::setup_header_curl_options(CURL* curl)
 {    
     setup_common_curl_options(curl);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 15L); 
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L); 
+    
     curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
     curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, &LLMDownloader::header_callback);
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, discard_callback); // <-- avoids stdout
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, discard_callback); 
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, nullptr);
 }
 

--- a/app/lib/LLMSelectionDialog.cpp
+++ b/app/lib/LLMSelectionDialog.cpp
@@ -1093,14 +1093,14 @@ void LLMSelectionDialog::refresh_downloader()
         downloader = std::make_unique<LLMDownloader>(env_url, explicit_path);
     }
 
-    if (downloader->get_local_download_status() == LLMDownloader::DownloadStatus::InProgress) {
-        try {
-            downloader->init_if_needed();
-        } catch (const std::exception& ex) {
-            set_status_message(QString::fromStdString(ex.what()));
-            downloader.reset();
-        }
-    }
+    // if (downloader->get_local_download_status() == LLMDownloader::DownloadStatus::InProgress) {
+    //     try {
+    //         downloader->init_if_needed();
+    //     } catch (const std::exception& ex) {
+    //         set_status_message(QString::fromStdString(ex.what()));
+    //         downloader.reset();
+    //     }
+    // }
 }
 
 void LLMSelectionDialog::handle_delete_download()
@@ -1539,14 +1539,14 @@ void LLMSelectionDialog::refresh_visual_llm_download_entry(VisualLlmDownloadEntr
                                                             QStringLiteral("#2e7d32")));
     }
 
-    if (entry.downloader->get_local_download_status() == LLMDownloader::DownloadStatus::InProgress) {
-        try {
-            entry.downloader->init_if_needed();
-        } catch (const std::exception& ex) {
-            set_visual_status_message(entry, QString::fromStdString(ex.what()));
-            entry.downloader.reset();
-        }
-    }
+    // if (entry.downloader->get_local_download_status() == LLMDownloader::DownloadStatus::InProgress) {
+    //     try {
+    //         entry.downloader->init_if_needed();
+    //     } catch (const std::exception& ex) {
+    //         set_visual_status_message(entry, QString::fromStdString(ex.what()));
+    //         entry.downloader.reset();
+    //     }
+    // }
 }
 
 void LLMSelectionDialog::update_visual_llm_download_entry(VisualLlmDownloadEntry& entry)
@@ -1716,12 +1716,12 @@ void LLMSelectionDialog::start_visual_llm_download(VisualLlmDownloadEntry& entry
         return;
     }
 
-    try {
-        entry.downloader->init_if_needed();
-    } catch (const std::exception& ex) {
-        DialogUtils::show_error_dialog(this, ex.what());
-        return;
-    }
+    // try {
+    //     entry.downloader->init_if_needed();
+    // } catch (const std::exception& ex) {
+    //     DialogUtils::show_error_dialog(this, ex.what());
+    //     return;
+    // }
 
     entry.is_downloading = true;
     if (entry.download_button) {
@@ -2012,12 +2012,12 @@ void LLMSelectionDialog::start_download()
         return;
     }
 
-    try {
-        downloader->init_if_needed();
-    } catch (const std::exception& ex) {
-        DialogUtils::show_error_dialog(this, ex.what());
-        return;
-    }
+    // try {
+    //     downloader->init_if_needed();
+    // } catch (const std::exception& ex) {
+    //     DialogUtils::show_error_dialog(this, ex.what());
+    //     return;
+    // }
 
     is_downloading = true;
     update_local_download_choice_enabled_state();

--- a/app/lib/Utils.cpp
+++ b/app/lib/Utils.cpp
@@ -671,11 +671,25 @@ std::string Utils::get_default_llm_destination()
 
 std::string Utils::get_file_name_from_url(std::string url)
 {
+    // Strip fragment (#...) and query (?...) before extracting filename
+    auto fragment_pos = url.find('#');
+    if (fragment_pos != std::string::npos) {
+        url = url.substr(0, fragment_pos);
+    }
+    auto query_pos = url.find('?');
+    if (query_pos != std::string::npos) {
+        url = url.substr(0, query_pos);
+    }
+
     auto last_slash = url.find_last_of('/');
     if (last_slash == std::string::npos || last_slash == url.length() - 1) {
         throw std::runtime_error("Invalid download URL: can't extract filename");
     }
     std::string filename = url.substr(last_slash + 1);
+
+    if (filename.empty()) {
+        throw std::runtime_error("Invalid download URL: empty filename");
+    }
 
     return filename;
 }

--- a/tests/unit/test_utils.cpp
+++ b/tests/unit/test_utils.cpp
@@ -11,6 +11,19 @@ TEST_CASE("get_file_name_from_url extracts filename") {
     REQUIRE(Utils::get_file_name_from_url(url) == "mistral-7b.gguf");
 }
 
+TEST_CASE("get_file_name_from_url strips query parameters") {
+    REQUIRE(Utils::get_file_name_from_url(
+        "https://example.com/models/mistral-7b.gguf?download=true")
+        == "mistral-7b.gguf");
+}
+
+TEST_CASE("get_file_name_from_url strips fragments") {
+    REQUIRE(Utils::get_file_name_from_url(
+        "https://example.com/models/mistral-7b.gguf#section")
+        == "mistral-7b.gguf");
+}
+
+
 TEST_CASE("get_file_name_from_url rejects malformed input") {
     REQUIRE_THROWS_AS(Utils::get_file_name_from_url("https://example.com/"), std::runtime_error);
 }


### PR DESCRIPTION
This PR fixes the CURL head: time out reached error when downloading models on Windows under restricted networks. It also resolves the issue where the network requests block the main thread and freeze the UI. Lastly, it improves the URL filename extraction logic and adds unit tests.

Changes:

LLMDownloader.cpp: 
-Added automatic Windows system proxy detection using native WinHTTP APIs. libcurl now automatically uses the active proxy, preventing connection timing out for certain areas' users.
-Async & UI Responsiveness 
-Moved init_if_needed() from the UI main thread to the background download thread.

LLMSelectionDialog.cpp:  
-Removed 4 redundant synchronous network calls init_if_needed() causing the UI to freeze.

Utils.cpp: 
-Updated Utils::get_file_name_from_url to strip query parameters (?) and fragments (#) before extracting the filename.
-Test was added to test_utils.cpp