### PR TITLE
fix: keep byte-wise ctype checks ASCII-only so UTF-8 category labels survive on macOS

### DIFF
--- a/app/lib/CategorizationService.cpp
+++ b/app/lib/CategorizationService.cpp
@@ -1001,7 +1001,9 @@ std::string to_lower_copy_str(std::string value) {
 // Returns true when the label contains only allowed characters.
 bool contains_only_allowed_chars(const std::string& value) {
     for (unsigned char ch : value) {
-        if (std::iscntrl(ch)) {
+        // ASCII-only check: macOS locales report UTF-8 continuation bytes
+        // in 0x80-0x9F as control characters.
+        if (ch < 0x80 && std::iscntrl(ch)) {
             return false;
         }
         static const std::string forbidden = R"(<>:"/\|?*)";

--- a/app/lib/Utils.cpp
+++ b/app/lib/Utils.cpp
@@ -912,8 +912,10 @@ std::string Utils::sanitize_path_label(const std::string& value) {
     cleaned.reserve(utf8_value.size());
 
     // Replace invalid path characters and control chars with spaces.
+    // Byte-wise ctype checks must stay ASCII-only: macOS locales classify
+    // UTF-8 continuation bytes in 0x80-0x9F as control characters.
     for (unsigned char ch : utf8_value) {
-        if (std::iscntrl(ch)) {
+        if (ch < 0x80 && std::iscntrl(ch)) {
             continue;
         }
         if (invalid.find(static_cast<char>(ch)) != std::string::npos) {
@@ -928,7 +930,8 @@ std::string Utils::sanitize_path_label(const std::string& value) {
     collapsed.reserve(cleaned.size());
     bool prev_space = false;
     for (char ch : cleaned) {
-        const bool is_space = std::isspace(static_cast<unsigned char>(ch));
+        const unsigned char uch = static_cast<unsigned char>(ch);
+        const bool is_space = uch < 0x80 && std::isspace(uch);
         if (is_space) {
             if (!prev_space) {
                 collapsed.push_back(' ');
@@ -941,7 +944,10 @@ std::string Utils::sanitize_path_label(const std::string& value) {
 
     // Trim and drop trailing dots/spaces (Windows safety).
     std::string trimmed = trim_ws(collapsed);
-    while (!trimmed.empty() && (trimmed.back() == '.' || std::isspace(static_cast<unsigned char>(trimmed.back())))) {
+    while (!trimmed.empty() &&
+           (trimmed.back() == '.' ||
+            (static_cast<unsigned char>(trimmed.back()) < 0x80 &&
+             std::isspace(static_cast<unsigned char>(trimmed.back()))))) {
         trimmed.pop_back();
     }
 


### PR DESCRIPTION
## Problem

On macOS, the built-in `--self-test` suite fails one case:

```
[FAIL] large whitelist preserves unicode labels - Expected AB Testing ☁️ to survive prompt selection and parsing.
```

## Root cause

macOS libc (unlike glibc) classifies bytes `0x80-0x9F` as control characters under UTF-8 locales — its ctype tables keep Latin-1-style semantics for the upper byte range. Verified on macOS 15 (Darwin 25.5.0, Apple Silicon):

```c
setlocale(LC_ALL, "");          // e.g. en_US.UTF-8
iscntrl(0x81)  // -> 1 on macOS, 0 on glibc
iscntrl(0x8F)  // -> 1 on macOS, 0 on glibc
isspace(0xA0)  // -> 1 on macOS, 0 on glibc
```

Since Qt calls `setlocale(LC_ALL, "")` at startup, byte-wise `std::iscntrl()` / `std::isspace()` corrupt UTF-8 continuation bytes on macOS:

- `Utils::sanitize_path_label()` silently drops bytes `0x81`/`0x8F`, so a whitelist label like `AB Testing ☁️` (U+2601 U+FE0F = `E2 98 81 EF B8 8F`) is mangled before it reaches the prompt candidate list.
- `contains_only_allowed_chars()` rejects the same label during response validation, so the parsed category never survives.

Linux and Windows are unaffected, which is why CI stays green while macOS source builds fail the self-test.

## Fix

Guard the affected byte-wise ctype calls with an explicit ASCII range check (`ch < 0x80 && ...`) so multibyte UTF-8 sequences pass through untouched. This matches the effective glibc behavior the code already relies on. 12 insertions, 4 deletions, no behavior change for ASCII input.

## Verification

Built from source on macOS 15 / Apple Silicon (M4 Max), Qt 6.11.1:

Before:
```
[PASS] large whitelist uses compact prompt candidates
[PASS] large whitelist prefers learned candidate
[FAIL] large whitelist preserves unicode labels
Self-test result: FAIL
```

After:
```
[PASS] large whitelist uses compact prompt candidates
[PASS] large whitelist prefers learned candidate
[PASS] large whitelist preserves unicode labels
Self-test result: PASS
```

## Note on remaining sites

The same byte-wise ctype pattern exists elsewhere (e.g. `to_lower_copy_str()` maps `0xC3` -> `0xE3` on macOS, and trim/collapse helpers treat `0xA0` — the trailing byte of `à` — as whitespace). This PR intentionally only fixes the sites on the failing self-test path to keep the change minimal; happy to follow up with a broader pass if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)